### PR TITLE
Fix #7 - ${1} description

### DIFF
--- a/autoseo.php
+++ b/autoseo.php
@@ -222,7 +222,7 @@ class AutoSeoPlugin extends Plugin
  
         $content = $this->cleanMarkdown($content);
         // truncate the content to the number of words set in config
-        $contentSmall = mb_ereg_replace('((\w+\W*){'.$length.'}(\w+))(.*)', '${1}', $content); // beware if content is less than length words, it will be nulled    
+        $contentSmall = mb_ereg_replace('((\w+\W*){'.$length.'}(\w+))(.*)', '\\1', $content); // beware if content is less than length words, it will be nulled    
         if ($contentSmall == '' ) $contentSmall = $content;
  
         return $contentSmall;


### PR DESCRIPTION
With the change from preg_replace to mb_ereg_replace the group placeholder changed

FIxes #7 

Example what happened there: https://3v4l.org/vYLQ3